### PR TITLE
Refactor/repo structure

### DIFF
--- a/app/src/main/java/com/schedule/shareships/data/repository/DataSourceRepository.kt
+++ b/app/src/main/java/com/schedule/shareships/data/repository/DataSourceRepository.kt
@@ -3,7 +3,7 @@ package com.schedule.shareships.data.repository
 import com.schedule.shareships.data.source.SchedulePagingSource
 import com.schedule.shareships.model.Schedule
 
-interface FirestoreRepository {
+interface DataSourceRepository {
     suspend fun insertSchedule(schedule: Schedule)
     fun getSchedule(): SchedulePagingSource
 }

--- a/app/src/main/java/com/schedule/shareships/data/repository/DataSourceRepositoryImpl.kt
+++ b/app/src/main/java/com/schedule/shareships/data/repository/DataSourceRepositoryImpl.kt
@@ -7,9 +7,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DefaultFirestoreRepository @Inject constructor(
+class DataSourceRepositoryImpl @Inject constructor(
     private val firestoreDataSource: FirestoreDataSource
-) : FirestoreRepository {
+) : DataSourceRepository {
 
     override fun getSchedule(): SchedulePagingSource {
         return SchedulePagingSource(firestoreDataSource.getScheduleQuery())

--- a/app/src/main/java/com/schedule/shareships/data/repository/DataSourceRepositoryImpl.kt
+++ b/app/src/main/java/com/schedule/shareships/data/repository/DataSourceRepositoryImpl.kt
@@ -12,7 +12,7 @@ class DataSourceRepositoryImpl @Inject constructor(
 ) : DataSourceRepository {
 
     override fun getSchedule(): SchedulePagingSource {
-        return SchedulePagingSource(firestoreDataSource.getScheduleQuery())
+        return SchedulePagingSource(firestoreDataSource.getSchedulesQuery())
     }
 
     override suspend fun insertSchedule(schedule: Schedule) {

--- a/app/src/main/java/com/schedule/shareships/data/repository/DefaultFirestoreRepository.kt
+++ b/app/src/main/java/com/schedule/shareships/data/repository/DefaultFirestoreRepository.kt
@@ -1,7 +1,7 @@
 package com.schedule.shareships.data.repository
 
-import com.schedule.shareships.data.FirestoreDataSource
-import com.schedule.shareships.data.SchedulePagingSource
+import com.schedule.shareships.data.source.FirestoreDataSource
+import com.schedule.shareships.data.source.SchedulePagingSource
 import com.schedule.shareships.model.Schedule
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/main/java/com/schedule/shareships/data/repository/FirestoreRepository.kt
+++ b/app/src/main/java/com/schedule/shareships/data/repository/FirestoreRepository.kt
@@ -1,6 +1,6 @@
 package com.schedule.shareships.data.repository
 
-import com.schedule.shareships.data.SchedulePagingSource
+import com.schedule.shareships.data.source.SchedulePagingSource
 import com.schedule.shareships.model.Schedule
 
 interface FirestoreRepository {

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
@@ -1,4 +1,4 @@
-package com.schedule.shareships.data
+package com.schedule.shareships.data.source
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
@@ -14,7 +14,7 @@ interface FirestoreDataSource {
 
     suspend fun getFollowingUsersQuery(email: String): Query
 
-    suspend fun getFollowedUsersSchedulesQuery(email: String): Query
+    suspend fun getUsersSchedulesQuery(email: String): Query
 
     suspend fun followUser(email: String, followedUserEmail: String)
 }

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
@@ -12,6 +12,8 @@ interface FirestoreDataSource {
 
     suspend fun getFollowedUsersQuery(email: String): Query
 
+    suspend fun getFollowingUsersQuery(email: String): Query
+
     suspend fun getFollowedUsersSchedulesQuery(email: String): Query
 
     suspend fun followUser(email: String, followedUserEmail: String)

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSource.kt
@@ -1,21 +1,18 @@
 package com.schedule.shareships.data.source
 
-import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.schedule.shareships.model.Schedule
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class FirestoreDataSource @Inject constructor(
-    firestore: FirebaseFirestore
-) {
+interface FirestoreDataSource {
+    fun getSchedulesQuery(): Query
+    suspend fun insertSchedule(schedule: Schedule)
 
-    private val scheduleRef = firestore.collection("schedule")
+    //TODO：返り値は現状String型だが、後々変更する可能性あり
+    suspend fun getUserData(email: String): String
 
-    fun getScheduleQuery() = scheduleRef.orderBy("date", Query.Direction.ASCENDING)
+    suspend fun getFollowedUsersQuery(email: String): Query
 
-    fun insertSchedule(schedule: Schedule) {
-        scheduleRef.add(schedule)
-    }
+    suspend fun getFollowedUsersSchedulesQuery(email: String): Query
+
+    suspend fun followUser(email: String, followedUserEmail: String)
 }

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSourceImpl.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSourceImpl.kt
@@ -23,6 +23,10 @@ class FirestoreDataSourceImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
+    override suspend fun getFollowingUsersQuery(email: String): Query {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun getFollowedUsersSchedulesQuery(email: String): Query {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSourceImpl.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSourceImpl.kt
@@ -27,7 +27,7 @@ class FirestoreDataSourceImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun getFollowedUsersSchedulesQuery(email: String): Query {
+    override suspend fun getUsersSchedulesQuery(email: String): Query {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSourceImpl.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/FirestoreDataSourceImpl.kt
@@ -1,0 +1,37 @@
+package com.schedule.shareships.data.source
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.schedule.shareships.model.Schedule
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FirestoreDataSourceImpl @Inject constructor(
+    firestore: FirebaseFirestore
+) : FirestoreDataSource{
+
+    private val scheduleRef = firestore.collection("schedule")
+
+    override fun getSchedulesQuery() = scheduleRef.orderBy("date", Query.Direction.ASCENDING)
+
+    override suspend fun getUserData(email: String): String {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getFollowedUsersQuery(email: String): Query {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getFollowedUsersSchedulesQuery(email: String): Query {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun followUser(email: String, followedUserEmail: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun insertSchedule(schedule: Schedule) {
+        scheduleRef.add(schedule)
+    }
+}

--- a/app/src/main/java/com/schedule/shareships/data/source/SchedulePagingSource.kt
+++ b/app/src/main/java/com/schedule/shareships/data/source/SchedulePagingSource.kt
@@ -1,4 +1,4 @@
-package com.schedule.shareships.data
+package com.schedule.shareships.data.source
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState

--- a/app/src/main/java/com/schedule/shareships/di/FirestoreDataSourceModule.kt
+++ b/app/src/main/java/com/schedule/shareships/di/FirestoreDataSourceModule.kt
@@ -1,0 +1,21 @@
+package com.schedule.shareships.di
+
+import com.schedule.shareships.data.source.FirestoreDataSource
+import com.schedule.shareships.data.source.FirestoreDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class FirestoreDataSourceModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindFirestoreDataSource(
+        firestoreDataSourceImpl: FirestoreDataSourceImpl
+    ): FirestoreDataSource
+
+}

--- a/app/src/main/java/com/schedule/shareships/di/RepositoryModule.kt
+++ b/app/src/main/java/com/schedule/shareships/di/RepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.schedule.shareships.di
 
-import com.schedule.shareships.data.repository.DefaultFirestoreRepository
-import com.schedule.shareships.data.repository.FirestoreRepository
+import com.schedule.shareships.data.repository.DataSourceRepositoryImpl
+import com.schedule.shareships.data.repository.DataSourceRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,6 +15,6 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun provideFirestoreRepository(
-        defaultFirestoreRepository: DefaultFirestoreRepository
-    ): FirestoreRepository
+        defaultFirestoreRepository: DataSourceRepositoryImpl
+    ): DataSourceRepository
 }

--- a/app/src/main/java/com/schedule/shareships/ui/viewmodel/PostScheduleViewModel.kt
+++ b/app/src/main/java/com/schedule/shareships/ui/viewmodel/PostScheduleViewModel.kt
@@ -2,7 +2,7 @@ package com.schedule.shareships.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.schedule.shareships.data.repository.FirestoreRepository
+import com.schedule.shareships.data.repository.DataSourceRepository
 import com.schedule.shareships.model.Schedule
 import com.schedule.shareships.utils.Constants
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class PostScheduleViewModel @Inject constructor(
-    private val firestoreRepository: FirestoreRepository
+    private val dataSourceRepository: DataSourceRepository
 ) : ViewModel() {
 
     //テキストフィールドのUI状態やローディング状態を管理する状態管理
@@ -206,7 +206,7 @@ class PostScheduleViewModel @Inject constructor(
                 _textFieldUiState.value = _textFieldUiState.value.copy(
                     isLoading = true
                 )
-                firestoreRepository.insertSchedule(schedule)
+                dataSourceRepository.insertSchedule(schedule)
                 _onPressedPostButtonEvent.emit(true)
             }
         }

--- a/app/src/main/java/com/schedule/shareships/ui/viewmodel/ScheduleListViewModel.kt
+++ b/app/src/main/java/com/schedule/shareships/ui/viewmodel/ScheduleListViewModel.kt
@@ -8,14 +8,14 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.schedule.shareships.utils.Constants
 import com.schedule.shareships.model.Schedule
-import com.schedule.shareships.data.repository.FirestoreRepository
+import com.schedule.shareships.data.repository.DataSourceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
 @HiltViewModel
 class ScheduleListViewModel @Inject constructor(
-    private val repository: FirestoreRepository
+    private val repository: DataSourceRepository
 ) : ViewModel() {
     val items: Flow<PagingData<Schedule>> = Pager(
         config = PagingConfig(pageSize = Constants.PAGE_SIZE, enablePlaceholders = false),


### PR DESCRIPTION
## issueリンク
- 作成していない
## やったこと
- Dataフォルダのファイルドメインを変更
- FirestoreDataSourceをインターフェースで継承
  - ユーザデータの取得メソッドの追加
  - ユーザデータのフォロー・フォロワーの人を取得するメソッドの追加
  - フォロワー・フォロー・自分のスケジュールを取得するメソッド
## やらないこと
- Repositoryの抽象クラスにはsignIn・signOut・deleteAccountなどのFirebaseAuth周りのメソッドを実装していない
## できるようになること（ユーザ目線）
- 変化なし
## できなくなること（ユーザ目線）
- 変化なし
## 動作確認
- 特に問題はなし
## その他
- このRepositoryのみでデータレイヤの実装を行いますので、Firestore・FirebaseAuthのデータのやり取りはこの一つのRepositoryで済ませるようお願いいたします。